### PR TITLE
Fix some warnings, add meaningful errors

### DIFF
--- a/src/Application.hs
+++ b/src/Application.hs
@@ -20,7 +20,7 @@ module Application
     , db
     ) where
 
-import           Control.Monad.Logger                 (liftLoc, runLoggingT)
+import           Control.Monad.Logger                 (liftLoc) -- runLoggingT
 -- import Database.Persist.Postgresql          (createPostgresqlPool, pgConnStr,
 --                                              pgPoolSize, runSqlPool)
 import           Database.Persist.MongoDB             (MongoContext)
@@ -83,8 +83,8 @@ makeFoundation appSettings = do
         -- The App {..} syntax is an example of record wild cards. For more
         -- information, see:
         -- https://ocharles.org.uk/blog/posts/2014-12-04-record-wildcards.html
-        tempFoundation = mkFoundation $ error "connPool forced in tempFoundation"
-        logFunc = messageLoggerSource tempFoundation appLogger
+        -- tempFoundation = mkFoundation $ error "connPool forced in tempFoundation" TODO check if applicable, else remove
+        -- logFunc = messageLoggerSource tempFoundation appLogger TODO check if applicable, else remove
 
     -- Create the database connection pool
     -- pool <- flip runLoggingT logFunc $ createPoolConfig $ appDatabaseConf appSettings

--- a/src/Game/Board.hs
+++ b/src/Game/Board.hs
@@ -31,7 +31,7 @@ data Cell = Cell { _isFlagged        :: Bool,
                    _neighboringBombs :: Int,
                    _coordinate       :: Coordinate
                    } deriving (Show, Eq)
-makeLenses ''Cell                   
+makeLenses ''Cell
 
 type Board = Matrix Cell
 

--- a/src/Handler/GameR.hs
+++ b/src/Handler/GameR.hs
@@ -82,7 +82,7 @@ getCellTile True True False _  = "/static/assets/mine_wrong.svg"
 getCellTile False True True _  = "/static/assets/mine_red.svg"
 getCellTile True False _ _     = "/static/assets/flag.svg"
 getCellTile _ False _ _        = "/static/assets/closed.svg"
-getCellTile _ _ _ _            = undefined
+getCellTile _ _ _ _            = error "Invalid CellState"
 
 getCellTileWon :: Bool -> Bool -> Bool -> Int -> String
 getCellTileWon False _ False 0    = "/static/assets/type0.svg"

--- a/src/Marshalling.hs
+++ b/src/Marshalling.hs
@@ -32,7 +32,7 @@ gameStateToGameStateEntity state = GameStateEntity {
                                        _gameStateEntityStatus        = show (state ^. status),
                                        _gameStateEntityLastStartedAt = state ^. lastStartedAt,
                                        _gameStateEntityTimeElapsed   = state ^. timeElapsed
-                                   } where boardToRows board = map (Row . map cellToCellEntity) (Data.Matrix.toLists board)
+                                   } where boardToRows board_ = map (Row . map cellToCellEntity) (Data.Matrix.toLists board_)
 
 gameStateEntityToGameState :: GameStateEntity -> GameState
 gameStateEntityToGameState entity = GameState {
@@ -53,7 +53,7 @@ statusEntityToStatus "Ongoing" = Ongoing
 statusEntityToStatus "Won"     = Won
 statusEntityToStatus "Lost"    = Lost
 statusEntityToStatus "Paused"  = Paused
-statusEntityToStatus _         = undefined
+statusEntityToStatus _         = error "Invalid StatusEntity"
 
 cellToCellEntity :: Cell -> CellEntity
 cellToCellEntity (Cell flagged revealed hasBomb neighbors (x,y)) = CellEntity {
@@ -83,10 +83,10 @@ moveEntityToMove :: MoveEntity -> Move
 moveEntityToMove (MoveEntity "Flag" (Just x) (Just y) timeStamp)    = Flag (x,y) timeStamp
 moveEntityToMove (MoveEntity "Reveal" (Just x) (Just y) timeStamp)  = Reveal (x,y) timeStamp
 moveEntityToMove (MoveEntity "RevealAllNonFlagged" _ _ timeStamp)   = RevealAllNonFlagged timeStamp
-moveEntityToMove _ = undefined
+moveEntityToMove _ = error "Invalid MoveEntity"
 
 moveRequestToMove :: MoveRequest -> UTCTime -> Move
 moveRequestToMove (MoveRequest "RevealAllNonFlagged" _ _) timeStamp = RevealAllNonFlagged timeStamp
 moveRequestToMove (MoveRequest "Flag" (Just x) (Just y)) timeStamp  = Flag (x,y) timeStamp
 moveRequestToMove (MoveRequest "Reveal"(Just x) (Just y)) timeStamp = Reveal (x,y) timeStamp
-moveRequestToMove _ _ = undefined
+moveRequestToMove _ _ = error "Invalid MoveRequest"

--- a/templates/game.julius
+++ b/templates/game.julius
@@ -39,7 +39,7 @@ const makeMove = (x, y, gameId, event) => {
 // Reveal all
 const revealAll = (gameId) => {
 
-    console.log("revealAll");
+    console.log("REVEAL ALL", { gameId });
 
     $.ajax({
         url: "/game/" + gameId,


### PR DESCRIPTION
##### APPROACH
- PR points at #25 
- renamed board to `board_` to fix shadowing
- commented out unused parts of code in `Application.hs`, it was not in the MongoDB template, but I wanted at first to make use of it. let's see if we have time to include or evaluate it.
- changed `undefined` to `error "msg"` to provide meaningful feedback, e.g. in the Example the action Type is wrong
```bash
09/Sep/2020:23:01:49 +0200 [Error#yesod-core] Invalid MoveRequest.
CallStack (from HasCallStack):
  error, called at src/Marshalling.hs:92:25 in minesweepskell-0.1.0-8uy8wOlansCFGGguNCw8nf:Marshalling @(yesod-core-1.6.18-1gehdd9uaBvCwfXwrHEsNB:Yesod.Core.Class.Yesod src/Yesod/Core/Class/Yesod.hs:688:5)
PUT /game/freeletics
  Request Body: {"action":"Reasdfasfdveal","coordX":1,"coordY":6}
  Accept: */*
  Status: 500 Internal Server Error 0.008828s
```
- only two `warning: [-Wunused-top-binds]` left, see https://gitlab.haskell.org/ghc/ghc/-/issues/12920
